### PR TITLE
Add blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+  # main
+  
+  - Added getBlob and createBlob
+  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
   # main
   
-  - Added getBlob and createBlob
+  - Added getBlobAsBase64 and createBlob
   

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2019 Aaron VonderHaar
+Copyright (c) 2019-2020 Aaron VonderHaar
+Copyright (c) 2020 James Carlson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Github.elm
+++ b/src/Github.elm
@@ -3,7 +3,7 @@ module Github exposing
     , getCommit, createCommit
     , PullRequest, getPullRequests, getPullRequest, createPullRequest
     , getFileContents, updateFileContents
-    , createBlob, getBlob
+    , createBlob, getBlobAsBase64
     , getComments, createComment
     )
 
@@ -13,7 +13,7 @@ module Github exposing
 @docs getCommit, createCommit
 @docs PullRequest, getPullRequests, getPullRequest, createPullRequest
 @docs getFileContents, updateFileContents
-@docs createBlob, getBlob
+@docs createBlob, getBlobAsBase64
 
 
 ## Issues
@@ -514,7 +514,7 @@ This function returns the blob content as a base64-encoded string.
 NOTE: Not all output fields are supported yet. Pull requests adding more complete support are welcome.
 
 -}
-getBlob :
+getBlobAsBase64 :
     { repo : String
     , file_sha : String
     }
@@ -522,7 +522,7 @@ getBlob :
         Task Http.Error
             { content : String
             }
-getBlob params =
+getBlobAsBase64 params =
     let
         decoder =
             Json.Decode.map

--- a/src/Github.elm
+++ b/src/Github.elm
@@ -516,7 +516,7 @@ NOTE: Not all output fields are supported yet. Pull requests adding more complet
 -}
 getBlobAsBase64 :
     { repo : String
-    , file_sha : String
+    , fileSha : String
     }
     ->
         Task Http.Error
@@ -537,7 +537,7 @@ getBlobAsBase64 params =
         , headers =
             [ Http.header "Accept" "application/vnd.github.v3+json"
             ]
-        , url = "https://api.github.com/repos/" ++ params.repo ++ "/git/blobs" ++ "/" ++ params.file_sha
+        , url = "https://api.github.com/repos/" ++ params.repo ++ "/git/blobs" ++ "/" ++ params.fileSha
         , body = Http.emptyBody
         , resolver = jsonResolver decoder
         , timeout = Nothing

--- a/src/Github.elm
+++ b/src/Github.elm
@@ -518,11 +518,19 @@ getBlob :
     { repo : String
     , file_sha : String
     }
-    -> Task Http.Error String
+    ->
+        Task Http.Error
+            { content : String
+            }
 getBlob params =
     let
         decoder =
-            Json.Decode.at [ "content" ] Json.Decode.string
+            Json.Decode.map
+                (\content ->
+                    { content = content
+                    }
+                )
+                (Json.Decode.at [ "content" ] Json.Decode.string)
     in
     Http.task
         { method = "GET"

--- a/src/Github.elm
+++ b/src/Github.elm
@@ -507,11 +507,12 @@ jsonResolver decoder =
                     Err (Http.BadStatus metadata.statusCode)
 
 
+{-| See <https://docs.github.com/en/rest/reference/git#get-a-blob>
 
--- Added by JC --
+This function returns the blob content as a base64-encoded string.
 
+NOTE: Not all output fields are supported yet. Pull requests adding more complete support are welcome.
 
-{-| Return a blob with given {sha} from {owner}{repo} as a base64-encoded string.
 -}
 getBlob :
     { owner : String
@@ -536,8 +537,10 @@ getBlob params =
         }
 
 
-{-| Create a blob in {owner}/{repo} with the given {content} using the
-{authToken}
+{-| See <https://docs.github.com/en/rest/reference/git#create-a-blob>
+
+NOTE: Not all output fields are supported yet. Pull requests adding more complete support are welcome.
+
 -}
 createBlob :
     { authToken : String

--- a/src/Github.elm
+++ b/src/Github.elm
@@ -516,7 +516,7 @@ NOTE: Not all output fields are supported yet. Pull requests adding more complet
 -}
 getBlob :
     { repo : String
-    , sha : String
+    , file_sha : String
     }
     -> Task Http.Error String
 getBlob params =
@@ -529,7 +529,7 @@ getBlob params =
         , headers =
             [ Http.header "Accept" "application/vnd.github.v3+json"
             ]
-        , url = "https://api.github.com/repos/" ++ params.repo ++ "/git/blobs" ++ "/" ++ params.sha
+        , url = "https://api.github.com/repos/" ++ params.repo ++ "/git/blobs" ++ "/" ++ params.file_sha
         , body = Http.emptyBody
         , resolver = jsonResolver decoder
         , timeout = Nothing

--- a/src/Github.elm
+++ b/src/Github.elm
@@ -515,8 +515,7 @@ NOTE: Not all output fields are supported yet. Pull requests adding more complet
 
 -}
 getBlob :
-    { owner : String
-    , repo : String
+    { repo : String
     , sha : String
     }
     -> Task Http.Error String
@@ -530,7 +529,7 @@ getBlob params =
         , headers =
             [ Http.header "Accept" "application/vnd.github.v3+json"
             ]
-        , url = "https://api.github.com/repos/" ++ params.owner ++ "/" ++ params.repo ++ "/git/blobs" ++ "/" ++ params.sha
+        , url = "https://api.github.com/repos/" ++ params.repo ++ "/git/blobs" ++ "/" ++ params.sha
         , body = Http.emptyBody
         , resolver = jsonResolver decoder
         , timeout = Nothing
@@ -544,7 +543,6 @@ NOTE: Not all output fields are supported yet. Pull requests adding more complet
 -}
 createBlob :
     { authToken : String
-    , owner : String
     , repo : String
     , content : String
     }
@@ -564,7 +562,7 @@ createBlob params =
             [ Http.header "Authorization" ("token " ++ params.authToken)
             , Http.header "Accept" "application/vnd.github.v3+json"
             ]
-        , url = "https://api.github.com/repos/" ++ params.owner ++ "/" ++ params.repo ++ "/git/blobs"
+        , url = "https://api.github.com/repos/" ++ params.repo ++ "/git/blobs"
         , body =
             Http.jsonBody
                 (Json.Encode.object


### PR DESCRIPTION
Changes from PR #1:
- moved some of the added doc comments to just be in the CHANGELOG
- For the switch from `repo="user/project"` to `owner="user", repo="project`, I think that's a good change, but I'd like to keep all the functions consistent and hold off on that change for just a bit (I made a new #6 to track that)
- I renamed some parameters to exactly match the naming the github API docs
- I renamed getBlob to `getBlobAsBase64` to make it extra clear that this function won't do the decode, and to leave room for adding a `getBlob` that maybe does do the decoding at some point in the future as a minor version change